### PR TITLE
ops+ci: Linear workflows, docs, and conventions

### DIFF
--- a/.github/workflows/linear-ci-block.yml
+++ b/.github/workflows/linear-ci-block.yml
@@ -37,11 +37,7 @@ jobs:
         run: |
           if [ -z "$LINEAR_API_KEY" ]; then echo "LINEAR_API_KEY not set; skipping"; exit 0; fi
           gql() { curl -sS -H "Content-Type: application/json" -H "Authorization: $LINEAR_API_KEY" -X POST https://api.linear.app/graphql -d "$1"; }
-          QUERY=$(cat <<'Q'
-          {"query":"query($key:String!){ issue(key:$key){ id team{ id } } }","variables":{"key":"__KEY__"}}
-Q
-          )
-          QUERY=${QUERY/__KEY__/$ISSUE_KEY}
+          QUERY='{"query":"query($key:String!){ issue(key:$key){ id team{ id } } }","variables":{"key":"'"$ISSUE_KEY"'"}}'
           ISSUE_JSON=$(gql "$QUERY")
           ISSUE_ID=$(echo "$ISSUE_JSON" | jq -r '.data.issue.id // empty')
           [ -z "$ISSUE_ID" ] && echo "Issue not found; skipping" && exit 0
@@ -49,12 +45,6 @@ Q
           STATUSES=$(gql '{"query":"query($teamId: String!){ team(id:$teamId){ states{ nodes{ id name type } } } }","variables":{"teamId":"'$TEAM_ID'"}}')
           STATUS_ID=$(echo "$STATUSES" | jq -r '.data.team.states.nodes[] | select(.name=="Blocked") | .id')
           [ -z "$STATUS_ID" ] && echo "Blocked not found; skipping" && exit 0
-          MUT=$(cat <<'M'
-          {"query":"mutation($id:String!,$stateId:String!,$comment:String!){ issueUpdate(id:$id, input:{ stateId:$stateId, description: null }){ success } commentCreate(input:{ issueId:$id, body:$comment }){ success } }","variables":{"id":"__ID__","stateId":"__STATE__","comment":"CI failed: __URL__"}}
-M
-          )
-          MUT=${MUT/__ID__/$ISSUE_ID}
-          MUT=${MUT/__STATE__/$STATUS_ID}
-          MUT=${MUT/__URL__/$RUN_URL}
+          MUT='{"query":"mutation($id:String!,$stateId:String!,$comment:String!){ issueUpdate(id:$id, input:{ stateId:$stateId, description: null }){ success } commentCreate(input:{ issueId:$id, body:$comment }){ success } }","variables":{"id":"'"$ISSUE_ID"'","stateId":"'"$STATUS_ID"'","comment":"CI failed: '"$RUN_URL"'"}}'
           gql "$MUT" | jq -r '.'
 

--- a/.github/workflows/linear-ci-block.yml
+++ b/.github/workflows/linear-ci-block.yml
@@ -2,11 +2,12 @@ name: Linear CI Failure Blocker
 
 on:
   workflow_run:
-    workflows: ["Lint", "Typecheck", "Test", "Build"]
+    workflows: ["Lint", "Typecheck", "Test", "Build", "Linear PR Status Sync", "Linear PR Review Sync"]
     types: [completed]
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   block-on-failure:

--- a/.github/workflows/linear-pr-review.yml
+++ b/.github/workflows/linear-pr-review.yml
@@ -1,0 +1,46 @@
+name: Linear PR Review Sync
+
+on:
+  pull_request:
+    types: [ready_for_review]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  to-in-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Linear issue key
+        id: extract
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            TEXT="${{ github.event.pull_request.title }}
+${{ github.event.pull_request.body }}"
+          else
+            # pull_request_review
+            TEXT="${{ github.event.pull_request.title }}
+${{ github.event.pull_request.body }}"
+          fi
+          echo "$TEXT" | grep -Eo '(AS|AUT)-[0-9]+' | head -n1 > key.txt || true
+          if [ -s key.txt ]; then echo "key=$(cat key.txt)" >> $GITHUB_OUTPUT; else echo "key=__skip__" >> $GITHUB_OUTPUT; fi
+      - name: Set Linear status to In Review
+        if: ${{ steps.extract.outputs.key != '__skip__' }}
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          ISSUE_KEY: ${{ steps.extract.outputs.key }}
+        run: |
+          [ -z "$LINEAR_API_KEY" ] && echo "Missing LINEAR_API_KEY" && exit 0
+          gql() { curl -sS -H "Content-Type: application/json" -H "Authorization: $LINEAR_API_KEY" -X POST https://api.linear.app/graphql -d "$1"; }
+          Q='{"query":"query($key:String!){ issue(key:$key){ id team{ id } } }","variables":{"key":"'$ISSUE_KEY'"}}'
+          J=$(gql "$Q"); IID=$(echo "$J"|jq -r '.data.issue.id // empty'); TID=$(echo "$J"|jq -r '.data.issue.team.id // empty')
+          [ -z "$IID" ] && echo "Issue not found" && exit 0
+          S=$(gql '{"query":"query($teamId:String!){ team(id:$teamId){ states{ nodes{ id name } } } }","variables":{"teamId":"'$TID'"}}')
+          SID=$(echo "$S"|jq -r '.data.team.states.nodes[]|select(.name=="In Review")|.id')
+          [ -z "$SID" ] && echo "In Review not found" && exit 0
+          M='{"query":"mutation($id:String!,$sid:String!){ issueUpdate(id:$id, input:{ stateId:$sid }){ success } }","variables":{"id":"'$IID'","sid":"'$SID'"}}'
+          gql "$M" | jq '.'
+

--- a/.github/workflows/linear-pr-review.yml
+++ b/.github/workflows/linear-pr-review.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: read
 
 jobs:
   to-in-review:

--- a/.github/workflows/linear-pr-review.yml
+++ b/.github/workflows/linear-pr-review.yml
@@ -19,12 +19,14 @@ jobs:
         id: extract
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            TEXT="${{ github.event.pull_request.title }}
-${{ github.event.pull_request.body }}"
+            TITLE="${{ github.event.pull_request.title }}"
+            BODY="${{ github.event.pull_request.body }}"
+            TEXT="$TITLE"$'\n'"$BODY"
           else
             # pull_request_review
-            TEXT="${{ github.event.pull_request.title }}
-${{ github.event.pull_request.body }}"
+            TITLE="${{ github.event.pull_request.title }}"
+            BODY="${{ github.event.pull_request.body }}"
+            TEXT="$TITLE"$'\n'"$BODY"
           fi
           echo "$TEXT" | grep -Eo '(AS|AUT)-[0-9]+' | head -n1 > key.txt || true
           if [ -s key.txt ]; then echo "key=$(cat key.txt)" >> $GITHUB_OUTPUT; else echo "key=__skip__" >> $GITHUB_OUTPUT; fi

--- a/.github/workflows/linear-pr-sync.yml
+++ b/.github/workflows/linear-pr-sync.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: read
 
 jobs:
   sync-linear-on-pr:

--- a/.github/workflows/linear-pr-sync.yml
+++ b/.github/workflows/linear-pr-sync.yml
@@ -19,8 +19,7 @@ jobs:
         run: |
           TITLE="${{ github.event.pull_request.title }}"
           BODY="${{ github.event.pull_request.body }}"
-          TEXT="$TITLE
-$BODY"
+          TEXT="$TITLE"$'\n'"$BODY"
           # Match common keys like AS-123 or AUT-123
           if echo "$TEXT" | grep -Eo '(AS|AUT)-[0-9]+' | head -n1 > key.txt; then
             KEY=$(cat key.txt | tr -d '\n')
@@ -61,11 +60,7 @@ $BODY"
               -X POST https://api.linear.app/graphql -d "$1"
           }
           # 1) Find issue by key
-          QUERY=$(cat <<'Q'
-          {"query":"query($key:String!){ issue(key:$key){ id team{ id } } }","variables":{"key":"__KEY__"}}
-Q
-          )
-          QUERY=${QUERY/__KEY__/$ISSUE_KEY}
+          QUERY='{"query":"query($key:String!){ issue(key:$key){ id team{ id } } }","variables":{"key":"'"$ISSUE_KEY"'"}}'
           ISSUE_JSON=$(gql "$QUERY")
           ISSUE_ID=$(echo "$ISSUE_JSON" | jq -r '.data.issue.id // empty')
           if [ -z "$ISSUE_ID" ]; then
@@ -74,18 +69,13 @@ Q
           fi
           TEAM_ID=$(echo "$ISSUE_JSON" | jq -r '.data.issue.team.id')
           # 2) Resolve status ID by name within team
-          STATUSES=$(gql '{"query":"query($teamId: String!){ team(id:$teamId){ states{ nodes{ id name type } } } }","variables":{"teamId":"'$TEAM_ID'"}}')
+          STATUSES=$(gql '{"query":"query($teamId: String!){ team(id:$teamId){ states{ nodes{ id name type } } } }","variables":{"teamId":"'"$TEAM_ID"'"}}')
           STATUS_ID=$(echo "$STATUSES" | jq -r --arg NAME "$TARGET_STATUS" '.data.team.states.nodes[] | select(.name==$NAME) | .id')
           if [ -z "$STATUS_ID" ]; then
             echo "Could not resolve status '$TARGET_STATUS' for team; skipping"
             exit 0
           fi
           # 3) Set issue state
-          MUTATION=$(cat <<'M'
-          {"query":"mutation($id:String!,$stateId:String!){ issueUpdate(id:$id, input:{ stateId:$stateId }){ success } }","variables":{"id":"__ID__","stateId":"__STATE__"}}
-M
-          )
-          MUTATION=${MUTATION/__ID__/$ISSUE_ID}
-          MUTATION=${MUTATION/__STATE__/$STATUS_ID}
+          MUTATION='{"query":"mutation($id:String!,$stateId:String!){ issueUpdate(id:$id, input:{ stateId:$stateId }){ success } }","variables":{"id":"'"$ISSUE_ID"'","stateId":"'"$STATUS_ID"'"}}'
           gql "$MUTATION" | jq -r '.'
 

--- a/.github/workflows/linear-qa-commands.yml
+++ b/.github/workflows/linear-qa-commands.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: read
   issues: read
+  actions: read
 
 jobs:
   qa-command:

--- a/.github/workflows/linear-qa-commands.yml
+++ b/.github/workflows/linear-qa-commands.yml
@@ -1,0 +1,53 @@
+name: Linear QA Commands
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  qa-command:
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse command
+        id: cmd
+        run: |
+          BODY="${{ github.event.comment.body }}"
+          if echo "$BODY" | grep -qi '^/qa pass'; then echo "cmd=pass" >> $GITHUB_OUTPUT; exit 0; fi
+          if echo "$BODY" | grep -qi '^/qa fail'; then echo "cmd=fail" >> $GITHUB_OUTPUT; exit 0; fi
+          echo "cmd=__skip__" >> $GITHUB_OUTPUT
+      - name: Resolve PR and Linear key
+        if: ${{ steps.cmd.outputs.cmd != '__skip__' }}
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=${{ github.event.issue.pull_request.url }}
+          gh api "$PR_URL" --jq '.title + "\n" + .body' > pr.txt
+          KEY=$(cat pr.txt | grep -Eo '(AS|AUT)-[0-9]+' | head -n1)
+          if [ -z "$KEY" ]; then echo "key=__skip__" >> $GITHUB_OUTPUT; else echo "key=$KEY" >> $GITHUB_OUTPUT; fi
+      - name: Apply QA result in Linear
+        if: ${{ steps.meta.outputs.key != '__skip__' }}
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          ISSUE_KEY: ${{ steps.meta.outputs.key }}
+          CMD: ${{ steps.cmd.outputs.cmd }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+        run: |
+          [ -z "$LINEAR_API_KEY" ] && echo "Missing LINEAR_API_KEY" && exit 0
+          gql() { curl -sS -H "Content-Type: application/json" -H "Authorization: $LINEAR_API_KEY" -X POST https://api.linear.app/graphql -d "$1"; }
+          Q='{"query":"query($key:String!){ issue(key:$key){ id team{ id } } }","variables":{"key":"'$ISSUE_KEY'"}}'
+          J=$(gql "$Q"); IID=$(echo "$J"|jq -r '.data.issue.id // empty'); TID=$(echo "$J"|jq -r '.data.issue.team.id // empty')
+          [ -z "$IID" ] && echo "Issue not found" && exit 0
+          S=$(gql '{"query":"query($teamId:String!){ team(id:$teamId){ states{ nodes{ id name type } } } }","variables":{"teamId":"'$TID'"}}')
+          if [ "$CMD" = "pass" ]; then TARGET="Done"; else TARGET="Todo"; fi
+          SID=$(echo "$S"|jq -r --arg N "$TARGET" '.data.team.states.nodes[]|select(.name==$N)|.id')
+          [ -z "$SID" ] && echo "Target status not found" && exit 0
+          M='{"query":"mutation($id:String!,$sid:String!,$c:String!){ issueUpdate(id:$id, input:{ stateId:$sid }){ success } commentCreate(input:{ issueId:$id, body:$c }){ success } }","variables":{"id":"'$IID'","sid":"'$SID'","c":"QA $CMD via $COMMENT_URL"}}'
+          gql "$M" | jq '.'
+

--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@
 - Work is managed in Linear using Issues, Cycles (sprints), and Projects/Epics.
 - Use fields: Priority (P0/P1/P2), Domain (fe, api, db, docker, oauth, ci, qa, sec, release, ux, senior, ops), Milestone (M1–M5), Sprint (Cycle), Risk (R/Y/G).
 - Status flow: Triage → Todo → In Progress → In Review → QA → Done/Blocked.
+
+
+<!-- Linear: AUT-5 -->

--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@
 
 
 <!-- Linear: AUT-5 -->
+
+## Linear Shortcuts
+
+- Board by Status: https://linear.app/autoschedme/issue/AUT-15/create-shared-view-board-by-status
+- Table by Domain: https://linear.app/autoschedme/issue/AUT-16/create-shared-view-table-by-domain-area
+- Roadmap by Project: https://linear.app/autoschedme/issue/AUT-17/create-shared-view-roadmap-by-project-m1-m5
+- M1 – Platform Foundations: https://linear.app/autoschedme/project/m1-platform-foundations-39f770f3d4e2
+- M2 – Core Product Ready: https://linear.app/autoschedme/project/m2-core-product-ready-0500061f5a68
+- M3 – Production Launch (eu-north-1): https://linear.app/autoschedme/project/m3-production-launch-eu-north-1-16bd3f691868
+- M4 – Scale & Optimize: https://linear.app/autoschedme/project/m4-scale-and-optimize-f232307bd5e7
+- M5 – Compliance & Trust: https://linear.app/autoschedme/project/m5-compliance-and-trust-8f2cc61de25b

--- a/ops/how-we-work.md
+++ b/ops/how-we-work.md
@@ -79,6 +79,40 @@ One sentence outcome.
 
 - Work item = Linear Issue. Statuses flow: Triage → Todo → In Progress → In Review → QA → Done/Blocked.
 - Fields: Priority (P0/P1/P2), Estimate, Domain (fe, api, db, docker, oauth, ci, qa, sec, release, ux, senior, ops), Agent (via labels `agent:*`), Milestone (M1–M5), Risk (R/Y/G).
+
+# How We Work (AutoSched)
+
+## Branching
+- Create branches from `dev`
+- Naming: `user/AS-123-short-slug` (e.g., `danny/AS-142-recurring-exceptions`)
+- Alt: `feature/AS-123-…`, `fix/AS-123-…`, `chore/AS-123-…`
+
+## Commits (Conventional)
+- `feat(api): add recurring exception rules (AS-142)`
+- `fix(web): correct DST rendering on booking grid (AS-166)`
+- Include Linear key in title or body (AS-### or AUT-###).
+
+## Pull Requests
+- Title: `[feat|fix|chore|docs|refactor] short summary (AS-###)`
+- Body: What/Why, screenshots/logs (if UI/bugfix), `Linear: AS-###`
+- All checks must pass; branches auto-deleted on merge
+
+## Status Flow
+Triage → Todo → In Progress → In Review → QA → Done
+
+Blocked is manual; unblock returns to Todo or In Progress
+
+## Projects (Focus-based)
+- Use Projects M1–M5 instead of time cycles
+- Assign each issue to the appropriate Project
+
+## Agent (Virtual Owner)
+- Use labels to denote virtual owner role: `agent:*` (Frontend Dev, Backend Dev, DB, OAuth/Security, CI/CD, QA, DevOps, UX, Product/PM, Release)
+- Real assignee remains Danny; `agent:*` indicates virtual owner role
+
+## Linking
+- PRs must mention the Linear issue key (AS-### or AUT-###)
+- Automations keep PR/CI state ↔ Linear status in sync
 - Cycles: 1–2 week sprints; enabled in the Linear workspace and referenced in Issues.
 - Roadmap/Epics: Use Projects/Epics to group Issues per milestone; PjM maintains.
 - Automations: New PR referencing an Issue moves it to In Progress; merged PR moves to In Review; CI failures set Blocked (via MCP integration where available).

--- a/ops/how-we-work.md
+++ b/ops/how-we-work.md
@@ -68,6 +68,7 @@ One sentence outcome.
 - area-fe, area-api, area-db, area-docker, area-oauth, area-ci, area-qa, area-security, area-release, area-ux, area-triage
 - type-bug, type-chore, type-feature, type-refactor, type-docs
 - priority-p0, priority-p1, priority-p2
+- agent:Frontend Dev, agent:Backend Dev, agent:DB, agent:OAuth/Security, agent:CI/CD, agent:QA, agent:DevOps, agent:UX, agent:Product/PM, agent:Release
 
 ## Linear Integration & Process
 
@@ -77,7 +78,7 @@ One sentence outcome.
 ### Project management in Linear
 
 - Work item = Linear Issue. Statuses flow: Triage → Todo → In Progress → In Review → QA → Done/Blocked.
-- Fields: Priority (P0/P1/P2), Estimate, Domain (fe, api, db, docker, oauth, ci, qa, sec, release, ux, senior, ops), Milestone (M1–M5), Sprint (Cycle), Risk (R/Y/G).
+- Fields: Priority (P0/P1/P2), Estimate, Domain (fe, api, db, docker, oauth, ci, qa, sec, release, ux, senior, ops), Agent (via labels `agent:*`), Milestone (M1–M5), Risk (R/Y/G).
 - Cycles: 1–2 week sprints; enabled in the Linear workspace and referenced in Issues.
 - Roadmap/Epics: Use Projects/Epics to group Issues per milestone; PjM maintains.
 - Automations: New PR referencing an Issue moves it to In Progress; merged PR moves to In Review; CI failures set Blocked (via MCP integration where available).

--- a/ops/prompts/qa-analyst.md
+++ b/ops/prompts/qa-analyst.md
@@ -6,7 +6,10 @@ Steps:
 1) Pull branch and run app/tests locally or in container
 2) Validate acceptance criteria and edge cases
 3) Record evidence (screenshots/logs)
-4) Mark `QA Passed` or `QA Failed`; if failed, reassign with repro steps
+4) Use PR comments to signal outcome:
+   - `/qa pass` → moves linked Linear issue to `Done`
+   - `/qa fail` → moves linked Linear issue to `Todo` and adds a note
+   If failed, include minimal repro steps and environment details.
 
 Guardrails:
 - Be precise and reproducible; avoid subjective language


### PR DESCRIPTION
Summary\n- Add Project Manager role; rebrand to AutoSched; switch ops docs to Linear\n- PR template\n- CI workflows scoped by paths\n- Linear automations: PR↔status, review→In Review, QA commands (/qa pass|fail), CI failure→Blocked\n- YAML fixes for workflows\n- How We Work conventions and Linear shortcuts in README\n\nLinked Issues\n- Linear: AUT-5, AUT-10..AUT-18\n\nChecks\n- Requires LINEAR_API_KEY secret (already set)